### PR TITLE
Move obs and var names to separate slot

### DIFF
--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -23,27 +23,11 @@ AbstractAnnData <- R6::R6Class("AbstractAnnData",
     },
     #' @field obs_names The obs_names slot
     obs_names = function(value) {
-      if (missing(value)) {
-        names <- names(self$obs)
-        if (is.null(names)) {
-          names <- character()
-        }
-        names
-      } else {
-        .abstract_function()
-      }
+      .abstract_function()
     },
     #' @field var_names The var_names slot
     var_names = function(value) {
-      if (missing(value)) {
-        names <- names(self$var)
-        if (is.null(names)) {
-          names <- character()
-        }
-        names
-      } else {
-        .abstract_function()
-      }
+      .abstract_function()
     }
   ),
   public = list(

--- a/R/InMemoryAnnData.R
+++ b/R/InMemoryAnnData.R
@@ -11,7 +11,65 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
     .obs = NULL,
     .var = NULL,
     .obs_names = NULL,
-    .var_names = NULL
+    .var_names = NULL,
+
+    #' @description validate a matrix (.X or .layers[...])
+    .validate_matrix = function(mat, obj_name) {
+      if (!is.null(mat)) {
+        if (nrow(mat) != nrow(self$obs))
+          stop("nrow(", obj_name, ") should be the same as nrow(obs)")
+        if (ncol(mat) != nrow(self$var))
+          stop("ncol(", obj_name, ") should be the same as nrow(var)")
+      
+        if (!is.null(rownames(mat))) {
+          warning("rownames(", obj_name, ") should be NULL, removing them from the matrix")
+          rownames(mat) <- NULL
+        }
+      
+        if (!is.null(colnames(mat))) {
+          warning("colnames(", obj_name, ") should be NULL, removing them from the matrix")
+          colnames(mat) <- NULL
+        }
+      }
+
+      mat
+    },
+
+    #' @description validate an obs data frame
+    .validate_obs = function(obs) {
+      if (is.null(obs)) stop("obs should be a data frame")
+      if (.row_names_info(obs) >= 0) {
+        warning("obs should not have any dimnames, removing them from the matrix")
+        rownames(obs) <- NULL
+      }
+      obs
+    },
+
+    #' @description validate a var data frame
+    .validate_var = function(var) {
+      if (is.null(var)) stop("var should be a data frame")
+      if (.row_names_info(var) >= 0) {
+        warning("var should not have any rownames, removing them from the matrix")
+        rownames(var) <- NULL
+      }
+      var
+    },
+
+    #' @description validate an obs_names vector
+    .validate_obs_names = function(obs_names) {
+      if (!is.null(obs_names)) {
+        if (length(obs_names) != nrow(self$obs)) stop("length(obs_names) should be the same as nrow(obs)")
+      }
+      obs_names
+    },
+
+    #' @description validate a var_names vector
+    .validate_var_names = function(var_names) {
+      if (!is.null(var_names)) {
+        if (length(var_names) != nrow(self$var)) stop("length(var_names) should be the same as nrow(var)")
+      }
+      var_names
+    }
   ),
   active = list(
     #' @field X The X slot
@@ -19,7 +77,7 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
       if (missing(value)) {
         private$.X
       } else {
-        private$.X <- .inmemoryanndata_check_matrix(value, self$obs, self$var, "X")
+        private$.X <- self$.validate_matrix(value, "X")
       }
     },
     #' @field obs The obs slot
@@ -27,7 +85,7 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
       if (missing(value)) {
         private$.obs
       } else {
-        private$.obs <- .inmemoryanndata_check_obs(value)
+        private$.obs <- self$.validate_obs(value)
       }
     },
     #' @field var The var slot
@@ -35,7 +93,7 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
       if (missing(value)) {
         private$.var
       } else {
-        private$.var <- .inmemoryanndata_check_var(value)
+        private$.var <- self$.validate_var(value)
       }
     },
     #' @field obs_names The obs_names slot
@@ -43,7 +101,7 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
       if (missing(value)) {
         private$.obs_names
       } else {
-        private$.obs_names <- .inmemoryanndata_check_obs_names(value)
+        private$.obs_names <- self$.validate_obs_names(value)
       }
     },
     #' @field var_names The var_names slot
@@ -51,7 +109,7 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
       if (missing(value)) {
         private$.var_names
       } else {
-        private$.var_names <- .inmemoryanndata_check_var_names(value)
+        private$.var_names <- self$.validate_var_names(value)
       }
     }
   ),
@@ -65,70 +123,22 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
     #' @param obs_names The obs_names slot
     #' @param var_names The var_names slot
     initialize = function(X = NULL, obs, var, obs_names = NULL, var_names = NULL) {
+      # check obs and var first
+      obs <- private$.validate_obs(obs)
+      var <- private$.validate_var(var)
+      private$.obs <- obs
+      private$.var <- var
+
       # check inputs
-      X <- .inmemoryanndata_check_matrix(X, obs, var, "X")
-      obs <- .inmemoryanndata_check_obs(obs)
-      var <- .inmemoryanndata_check_var(var)
-      obs_names <- .inmemoryanndata_check_obs_names(obs_names, obs)
-      var_names <- .inmemoryanndata_check_var_names(var_names, var)
+      X <- private$.validate_matrix(X, "X")
+      obs_names <- private$.validate_obs_names(obs_names)
+      var_names <- private$.validate_var_names(var_names)
 
       # store results
       private$.X <- X
-      private$.obs <- obs
-      private$.var <- var
       private$.obs_names <- obs_names
       private$.var_names <- var_names
     }
   )
 )
 
-.inmemoryanndata_check_matrix <- function(mat, obs, var, obj_name) {
-  if (!is.null(mat)) {
-    if (nrow(mat) != nrow(obs)) stop("nrow(", obj_name, ") should be the same as nrow(obs)")
-    if (ncol(mat) != nrow(var)) stop("ncol(", obj_name, ") should be the same as nrow(var)")
-  
-    if (!is.null(rownames(mat))) {
-      warning("rownames(", obj_name, ") should be NULL, removing them from the matrix")
-      rownames(mat) <- NULL
-    }
-  
-    if (!is.null(colnames(mat))) {
-      warning("colnames(", obj_name, ") should be NULL, removing them from the matrix")
-      colnames(mat) <- NULL
-    }
-  }
-
-  mat
-}
-
-.inmemoryanndata_check_obs <- function(obs) {
-  if (is.null(obs)) stop("obs should be a data frame")
-  if (.row_names_info(obs) >= 0) {
-    warning("obs should not have any dimnames, removing them from the matrix")
-    rownames(obs) <- NULL
-  }
-  obs
-}
-
-.inmemoryanndata_check_var <- function(var) {
-  if (is.null(var)) stop("var should be a data frame")
-  if (.row_names_info(var) >= 0) {
-    warning("var should not have any rownames, removing them from the matrix")
-    rownames(var) <- NULL
-  }
-  var
-}
-
-.inmemoryanndata_check_obs_names <- function(obs_names, obs) {
-  if (!is.null(obs_names)) {
-    if (length(obs_names) != nrow(obs)) stop("length(obs_names) should be the same as nrow(obs)")
-  }
-  obs_names
-}
-
-.inmemoryanndata_check_var_names <- function(var_names, var) {
-  if (!is.null(var_names)) {
-    if (length(var_names) != nrow(var)) stop("length(var_names) should be the same as nrow(var)")
-  }
-  var_names
-}

--- a/R/InMemoryAnnData.R
+++ b/R/InMemoryAnnData.R
@@ -17,7 +17,7 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
       if (missing(value)) {
         private$.X
       } else {
-        private$.X <- value
+        private$.X <- .inmemoryanndata_check_matrix(value, self$obs, self$var)
       }
     },
     #' @field obs The obs slot
@@ -25,6 +25,7 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
       if (missing(value)) {
         private$.obs
       } else {
+        # TODO: add checks
         private$.obs <- value
       }
     },
@@ -33,6 +34,7 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
       if (missing(value)) {
         private$.var
       } else {
+        # TODO: add checks
         private$.var <- value
       }
     }
@@ -88,10 +90,7 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
       }
 
       # check matrix
-      if (!is.null(X)) {
-        if (nrow(X) != nrow(obs)) stop("$obs should have the same number of rows as $X.")
-        if (ncol(X) != nrow(var)) stop("$obs should have the same number of rows as $X.")
-      }
+      X <- .inmemoryanndata_check_matrix(X, obs, var)
 
       private$.X <- X
       private$.obs <- obs
@@ -99,3 +98,15 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
     }
   )
 )
+
+.inmemoryanndata_check_matrix <- function(mat, obs, var) {
+  if (!is.null(mat)) {
+    if (nrow(mat) != nrow(obs)) stop("$X should have the same number of rows as $obs has rows.")
+    if (ncol(mat) != nrow(var)) stop("$X should have the same number of columns as $var has rows.")
+
+    rownames(mat) <- rownames(obs)
+    colnames(mat) <- rownames(var)
+  }
+
+  mat
+}

--- a/man/InMemoryAnnData.Rd
+++ b/man/InMemoryAnnData.Rd
@@ -17,6 +17,10 @@ Implementation of an in memory AnnData object.
 \item{\code{obs}}{The obs slot}
 
 \item{\code{var}}{The var slot}
+
+\item{\code{obs_names}}{The obs_names slot}
+
+\item{\code{var_names}}{The var_names slot}
 }
 \if{html}{\out{</div>}}
 }
@@ -43,19 +47,21 @@ Implementation of an in memory AnnData object.
 Creates a new instance of an in memory AnnData object.
 Inherits from AbstractAnnData
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{InMemoryAnnData$new(X = NULL, obs = NULL, var = NULL, shape = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{InMemoryAnnData$new(X = NULL, obs, var, obs_names = NULL, var_names = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{X}}{A #observations × #variables data matrix. A view of the data is used if the data type matches, otherwise, a copy is made.}
+\item{\code{X}}{The X slot}
 
-\item{\code{obs}}{Key-indexed one-dimensional observations annotation of length #observations.}
+\item{\code{obs}}{The obs slot}
 
-\item{\code{var}}{Key-indexed one-dimensional variables annotation of length #variables.}
+\item{\code{var}}{The var slot}
 
-\item{\code{shape}}{Shape list (#observations, #variables). Can only be provided if \code{X} is \code{NULL}.}
+\item{\code{obs_names}}{The obs_names slot}
+
+\item{\code{var_names}}{The var_names slot}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-inmemory-anndata.R
+++ b/tests/testthat/test-inmemory-anndata.R
@@ -1,26 +1,26 @@
 library(Matrix)
 
+# construct dummy X
+X <- Matrix::rsparsematrix(nrow = 10, ncol = 20, density = .1)
+
+# construct dummy obs
+obs <- data.frame(
+  cell_type = sample(c("tcell", "bcell"), 10, replace = TRUE),
+  cluster = sample.int(3, 10, replace = TRUE)
+)
+
+# construct dummy obs names
+obs_names <- paste0("cell_", seq_len(10))
+
+# construct dummy var
+var <- data.frame(
+  geneinfo = sample(c("a", "b", "c"), 20, replace = TRUE)
+)
+
+# construct dummy var names
+var_names <- paste0("gene", seq_len(20))
+
 test_that("create inmemory anndata", {
-  # construct dummy X
-  X <- Matrix::rsparsematrix(nrow = 10, ncol = 20, density = .1)
-
-  # construct dummy obs
-  obs <- data.frame(
-    cell_type = sample(c("tcell", "bcell"), 10, replace = TRUE),
-    cluster = sample.int(3, 10, replace = TRUE)
-  )
-
-  # construct dummy obs names
-  obs_names <- paste0("cell_", seq_len(10))
-
-  # construct dummy var
-  var <- data.frame(
-    geneinfo = sample(c("a", "b", "c"), 20, replace = TRUE)
-  )
-
-  # construct dummy var names
-  var_names <- paste0("gene", seq_len(20))
-
   ad <- InMemoryAnnData$new(
     X = X,
     obs = obs,
@@ -41,9 +41,61 @@ test_that("InMemoryAnnData$new() fails gracefully", {
   expect_error(InMemoryAnnData$new(var = data.frame(x = 1:3)))
 })
 
+test_that("InMemoryAnnData$new produces a warning if rownames are found", {
+  # check X with rownames
+  X_with_rownames <- X
+  rownames(X_with_rownames) <- obs_names
 
-test_that("InMemoryAnnData$new() validates dimensions", {
-  X <- matrix(0L, 3L, 5L)
-  expect_error(InMemoryAnnData$new(X = X, obs = data.frame(x = 1:5)))
-  expect_error(InMemoryAnnData$new(X = X, var = data.frame(x = 1:3)))
+  expect_warning({
+    InMemoryAnnData$new(
+      X = X_with_rownames,
+      obs = obs,
+      var = var,
+      obs_names = obs_names,
+      var_names = var_names
+    )
+  })
+
+  # check X with obsnames
+  X_with_colnames <- X
+  colnames(X_with_colnames) <- var_names
+
+  expect_warning({
+    InMemoryAnnData$new(
+      X = X_with_colnames,
+      obs = obs,
+      var = var,
+      obs_names = obs_names,
+      var_names = var_names
+    )
+  })
+
+  # check obs with rownames
+  obs_with_rownames <- obs
+  rownames(obs_with_rownames) <- obs_names
+
+  expect_warning({
+    InMemoryAnnData$new(
+      X = X,
+      obs = obs_with_rownames,
+      var = var,
+      obs_names = obs_names,
+      var_names = var_names
+    )
+  })
+
+  # check var with rownames
+  var_with_rownames <- var
+  rownames(var_with_rownames) <- var_names
+
+  expect_warning({
+    InMemoryAnnData$new(
+      X = X,
+      obs = obs,
+      var = var_with_rownames,
+      obs_names = obs_names,
+      var_names = var_names
+    )
+  })
+
 })

--- a/tests/testthat/test-inmemory-anndata.R
+++ b/tests/testthat/test-inmemory-anndata.R
@@ -6,27 +6,33 @@ test_that("create inmemory anndata", {
 
   # construct dummy obs
   obs <- data.frame(
-    row.names = paste0("cell_", seq_len(10)),
     cell_type = sample(c("tcell", "bcell"), 10, replace = TRUE),
     cluster = sample.int(3, 10, replace = TRUE)
   )
 
-  # construct dummy obs
+  # construct dummy obs names
+  obs_names <- paste0("cell_", seq_len(10))
+
+  # construct dummy var
   var <- data.frame(
-    row.names = paste0("gene", seq_len(20)),
     geneinfo = sample(c("a", "b", "c"), 20, replace = TRUE)
   )
+
+  # construct dummy var names
+  var_names <- paste0("gene", seq_len(20))
 
   ad <- InMemoryAnnData$new(
     X = X,
     obs = obs,
-    var = var
+    var = var,
+    obs_names = obs_names,
+    var_names = var_names
   )
 
   expect_equal(ad$X, X)
   expect_equal(ad$obs, obs)
   expect_equal(ad$var, var)
-  expect_identical(ad$shape(), dim(X))
+  expect_identical(ad$shape(), c(10L, 20L))
 })
 
 test_that("InMemoryAnnData$new() fails gracefully", {
@@ -40,17 +46,4 @@ test_that("InMemoryAnnData$new() validates dimensions", {
   X <- matrix(0L, 3L, 5L)
   expect_error(InMemoryAnnData$new(X = X, obs = data.frame(x = 1:5)))
   expect_error(InMemoryAnnData$new(X = X, var = data.frame(x = 1:3)))
-})
-
-test_that("dim() works", {
-  ad <- InMemoryAnnData$new(shape = c(1L, 1L))
-  expect_identical(ad$shape(), c(1L, 1L))
-
-  ## from obs and var, or if that fails X
-  ad <- InMemoryAnnData$new(obs = data.frame(x = 1:3), shape = c(3L, 0L))
-  expect_identical(ad$shape(), c(3L, 0L))
-  ad <- InMemoryAnnData$new(var = data.frame(x = 1:5), shape = c(0L, 5L))
-  expect_identical(ad$shape(), c(0L, 5L))
-  ad <- InMemoryAnnData$new(X = matrix(0L, 3L, 5L))
-  expect_identical(ad$shape(), c(3L, 5L))
 })


### PR DESCRIPTION
Since the obs_names and the var_names might soon be allowed to be non-character objects, we're storing them as a separate field in the in memory data structure